### PR TITLE
Initial ReleasePipeline support. Refactored to common PipelineHelper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.gradle
+build
+gradle
+/bin/
+.classpath
+.project
+.settings/

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
+function splitJvmOpts() {
+    JVM_OPTS=("$@")
+}
+eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+
+exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,90 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+if "%@eval[2+2]" == "4" goto 4NT_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+goto execute
+
+:4NT_args
+@rem Get arguments from the 4NT Shell from JP Software
+set CMD_LINE_ARGS=%$
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/com/rhc/CommandExecutor.groovy
+++ b/src/com/rhc/CommandExecutor.groovy
@@ -1,0 +1,43 @@
+package com.rhc
+
+import javax.management.InstanceOfQueryExp;
+
+
+def CommandOutput executeInJenkinsOrGroovy( String command ){
+
+	try {
+		sh "${command} > output.txt"
+		def outputString = readFile( 'output.txt' )
+		def CommandOutput output = new CommandOutput()
+		output.standardOut = outputString
+		return output
+	} catch (err){
+		if ( err instanceof MissingMethodException ) { // this means we are running outside of Jenkins
+			println( "Jenkins pipeline syntax failed. Falling back to groovy.execute() ")
+			def sout = new StringBuilder(), serr = new StringBuilder()
+			try {
+				def proc = command.execute()
+				proc.consumeProcessOutput(sout, serr)
+				proc.waitForOrKill( getCommandTimeout() )
+				println("Provided command ${command} suceeded with the following output:")
+				println "out:$sout\nerr:$serr"
+			} catch ( err2 ){
+				println("Provided command ${command} failed with the following exception:")
+				println( err2 )
+			} finally {
+				def CommandOutput output = new CommandOutput()
+				output.standardOut = sout
+				output.standardErr = serr
+				return output;
+			}
+		} else { // this means the command failed in Jenkins
+			throw err
+		}
+	}
+}
+
+//def Comma
+
+def getCommandTimeout(){
+	return 600000;
+}

--- a/src/com/rhc/CommandOutput.groovy
+++ b/src/com/rhc/CommandOutput.groovy
@@ -1,0 +1,6 @@
+package com.rhc
+
+class CommandOutput implements Serializable {
+	def String standardOut
+	def String standardErr
+}

--- a/src/com/rhc/DockerClient.groovy
+++ b/src/com/rhc/DockerClient.groovy
@@ -1,0 +1,65 @@
+package com.rhc
+
+def CommandOutput login( String host, String userToken ){
+	def commandExecutor = new CommandExecutor();
+	def command = "docker login -u='joe' -e='jholmes@redhat.com' -p=${userToken} ${host}"
+	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	return output
+}
+
+def CommandOutput pushOrPull( String operation, String repositoryString ){
+	def commandExecutor = new CommandExecutor();
+	def command = "docker ${operation} ${repositoryString}"
+	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	return output
+}
+
+def CommandOutput pull( String repositoryString ){
+	return pushOrPull( 'pull', repositoryString )
+}
+
+def CommandOutput push( String repositoryString ){
+	return pushOrPull( 'push', repositoryString )
+}
+
+def CommandOutput tagImage( String imageId, String repositoryStringWithVersion ){
+	def commandExecutor = new CommandExecutor();
+	def command = "docker tag ${imageId} ${repositoryStringWithVersion}"
+	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	return output
+}
+
+def CommandOutput retrieveImageId( String repositoryStringWithVersion ){
+	def commandExecutor = new CommandExecutor();
+	def command = "docker images --format '{{.ID}}' ${repositoryStringWithVersion}"
+	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	return output
+}
+
+def CommandOutput promoteImageBetweenRepositories( String currentRepositoryWithVersion, String newRepositoryWithVersion ){
+	pull( currentRepositoryWithVersion )
+	def CommandOutput imageId = retrieveImageId( currentRepositoryWithVersion )
+	tagImage( trimImageId(imageId.standardOut), newRepositoryWithVersion )
+	def CommandOutput commandOutput = push( newRepositoryWithVersion )
+	return commandOutput
+}
+
+def String trimImageId( String imageIdString ){
+	def String trimmedString = imageIdString.trim()
+	if ( trimmedString.length() > 12 ){
+		def length = trimmedString.length()
+		length -= 1
+		return trimmedString.trim().substring(1, length)
+	} else {
+		return trimmedString
+	}
+}
+
+def String buildRepositoryString( String host, String projectName, String imageName ){
+	return "${host}/${projectName}/${imageName}"
+}
+
+def String buildRepositoryStringWithVersion( String host, String projectName, String imageName, String version ){
+	def repositoryString = buildRepositoryString( host, projectName, imageName )
+	return "${repositoryString}:${version}"
+}

--- a/src/com/rhc/OpenShiftClient.groovy
+++ b/src/com/rhc/OpenShiftClient.groovy
@@ -1,0 +1,9 @@
+package com.rhc;
+
+def startBuild( String appName, String projectName ){
+    sh "oc start-build ${appName} -n ${projectName}" //-e ARTIFACT_URL=$hi"
+}
+
+def login( String host ){
+	sh "oc login ${host} --insecure-skip-tls-verify=true --username=joe --password=redhat" // This clearly shouldn't be hard coded
+}

--- a/src/com/rhc/OpenShiftClient.groovy
+++ b/src/com/rhc/OpenShiftClient.groovy
@@ -1,9 +1,38 @@
-package com.rhc;
+package com.rhc
 
-def startBuild( String appName, String projectName ){
-    sh "oc start-build ${appName} -n ${projectName}" //-e ARTIFACT_URL=$hi"
-}
+import com.rhc.CommandOutput
 
 def login( String host ){
-	sh "oc login ${host} --insecure-skip-tls-verify=true --username=joe --password=redhat" // This clearly shouldn't be hard coded
+	def commandExecutor = new CommandExecutor();
+	def command = "oc login ${host} --insecure-skip-tls-verify=true --username=joe --password=redhat"
+	commandExecutor.executeInJenkinsOrGroovy( command )
+}
+
+def CommandOutput startBuild( String appName, String projectName ){
+	def commandExecutor = new CommandExecutor();
+	def command = "oc start-build ${appName} -n ${projectName}"
+	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	return output
+}
+
+def CommandOutput getWhoAmI(){
+	def commandExecutor = new CommandExecutor();
+	def command = "oc whoami"
+	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	return output
+}
+
+def CommandOutput getUserToken(){
+	def commandExecutor = new CommandExecutor();
+	def command = "oc whoami -t"
+	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	return output
+}
+
+def String getTrimmedUserToken(){
+	def CommandOutput tokenOutput = getUserToken()
+	def tokenStream = tokenOutput.getStandardOut()
+	def tokenString = tokenStream.toString()
+	def tokenTrimmedString = tokenString.trim()
+	return tokenTrimmedString
 }

--- a/src/com/rhc/PipelineHelper.groovy
+++ b/src/com/rhc/PipelineHelper.groovy
@@ -1,0 +1,60 @@
+package com.rhc;
+
+def buildApplication( config ){
+    if ( config.appRootContext ){
+        dir ( config.appRootContext ){ 
+            executeBuildCommands(config)
+        }
+    } else {
+        executeBuildCommands(config)
+    }
+}
+
+def buildAndDeployImage( config ){
+    if ( config.buildImageCommands == null ){
+        echo 'No buildImageCommands, using default OpenShift image build and deploy'
+        startDefaultOpenShiftBuildAndDeploy( config )
+    } else {
+        echo 'Found buildImageCommands, executing in shell'
+        executeListOfShellCommands( config )
+    }
+}
+
+def getBuildTools(){
+	return ['node-0.10', 'Maven3.3.9'];
+}
+
+def startDefaultOpenShiftBuildAndDeploy( config ){
+    def oc = new OpenShiftClient()
+    oc.login( config.ocHost )
+    oc.startBuild( config.appName, config.projectName )
+}
+
+def executeBuildCommands( config ){
+    def tools = getBuildTools()
+
+    if ( config.buildTool == null ){
+        echo 'No build tool declared. Any commands will execute directly in the shell.'
+        executeListOfShellCommands( config )
+    } else if ( config.buildTool in tools ) {
+        echo "Using build tool: ${config.buildTool}"
+        executeListOfToolCommands( config )
+    } else {
+        error "${config.buildTool} is currently unsupported. Please select one of ${tools}."
+    }
+}
+
+def executeListOfShellCommands( config ){
+    for (int i=0; i<config.buildCommands.size(); i++){
+        def command = config.buildCommands[i]
+        sh "${command}" 
+    }
+}
+
+def executeListOfToolCommands( config ){
+    def toolHome = tool "${config.buildTool}"
+    for (int i=0; i<config.buildCommands.size(); i++){
+        def command = config.buildCommands[i]
+        sh "${toolHome}/bin/${command}" 
+    }
+}

--- a/src/com/rhc/PipelineHelper.groovy
+++ b/src/com/rhc/PipelineHelper.groovy
@@ -1,4 +1,6 @@
-package com.rhc;
+package com.rhc
+
+import javax.activation.CommandObject;
 
 def buildApplication( config ){
     if ( config.appRootContext ){
@@ -25,8 +27,7 @@ def getBuildTools(){
 }
 
 def startDefaultOpenShiftBuildAndDeploy( config ){
-    def oc = new OpenShiftClient()
-    oc.login( config.ocHost )
+	def oc = new OpenShiftClient()
     oc.startBuild( config.appName, config.projectName )
 }
 
@@ -35,26 +36,42 @@ def executeBuildCommands( config ){
 
     if ( config.buildTool == null ){
         echo 'No build tool declared. Any commands will execute directly in the shell.'
-        executeListOfShellCommands( config )
+        executeListOfShellCommands( config.buildCommands )
     } else if ( config.buildTool in tools ) {
         echo "Using build tool: ${config.buildTool}"
-        executeListOfToolCommands( config )
+        executeListOfToolCommands( config.buildCommands, config.buildTool )
     } else {
         error "${config.buildTool} is currently unsupported. Please select one of ${tools}."
     }
 }
 
-def executeListOfShellCommands( config ){
-    for (int i=0; i<config.buildCommands.size(); i++){
-        def command = config.buildCommands[i]
+def executeListOfShellCommands( commandList ){
+    for (int i=0; i<commandList.size(); i++){
+        def command = commandList[i]
         sh "${command}" 
     }
 }
 
-def executeListOfToolCommands( config ){
-    def toolHome = tool "${config.buildTool}"
-    for (int i=0; i<config.buildCommands.size(); i++){
-        def command = config.buildCommands[i]
+def executeListOfToolCommands( commandList, buildTool ){
+    def toolHome = tool "${buildTool}"
+    for (int i=0; i<commandList.size(); i++){
+        def command = commandList[i]
         sh "${toolHome}/bin/${command}" 
     }
+}
+
+def promoteImage( currentEnv, newEnv, config ){
+	def dockerClient = new DockerClient()
+	
+	def currentImageRepositoryWithVersion = dockerClient.buildRepositoryStringWithVersion( config.dockerRegistry, currentEnv.projectName, config.appName, 'latest' )
+	def newImageRepositoryWithVersion = dockerClient.buildRepositoryStringWithVersion( config.dockerRegistry, newEnv.projectName, config.appName, 'latest' )
+	
+	return dockerClient.promoteImageBetweenRepositories( currentImageRepositoryWithVersion, newImageRepositoryWithVersion )
+}
+
+def login( config ){
+	def oc = new OpenShiftClient()
+	oc.login( config.ocHost )
+	def docker = new DockerClient()
+	docker.login( config.dockerRegistry, oc.getTrimmedUserToken() )
 }

--- a/src/test/groovy/com/rhc/CommandExecutorTests.groovy
+++ b/src/test/groovy/com/rhc/CommandExecutorTests.groovy
@@ -1,0 +1,22 @@
+package com.rhc
+
+import org.junit.Test
+
+class CommandExecutorTests {
+
+	def commandExecutor = new CommandExecutor();
+	
+	@Test
+	void shouldPrintToStandardOut(){
+		def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( 'pwd' )
+		assert !output.standardOut.empty
+		assert output.standardErr.empty
+	}
+	
+	@Test
+	void shouldPrintToStandardError(){
+		def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( 'thisCommandShouldFail' )
+		assert output.standardOut.empty
+		assert output.standardErr.empty
+	}
+}

--- a/src/test/groovy/com/rhc/DockerClientTests.groovy
+++ b/src/test/groovy/com/rhc/DockerClientTests.groovy
@@ -1,0 +1,106 @@
+package com.rhc
+
+import org.junit.BeforeClass;
+import org.junit.Test
+
+class DockerClientTests {
+	
+	def static dockerRegistryHost = 'registry.env3-1.innovation.labs.redhat.com'
+	def static openShiftHost = 'env3-1-master.innovation.labs.redhat.com'
+	def static projectName = 'holmes-stage'
+	def static newProjectName = 'holmes-prod'
+	def static imageName = 'infographic-node-app'
+	def static dockerClient = new DockerClient()
+	def static openShiftClient = new OpenShiftClient()
+
+	
+	@BeforeClass
+	static void shouldLoginToRegistry(){
+		openShiftClient.login( openShiftHost )
+		def CommandOutput output = dockerClient.login( dockerRegistryHost, openShiftClient.getTrimmedUserToken() )
+		assert output.standardOut.contains( 'Login Succeeded' )
+	}
+	
+	@Test
+	void shouldFailToPullImage(){
+		def CommandOutput output = dockerClient.pull( getRepositoryBadString() )
+		assert output.standardErr.contains( 'not found' )
+	}
+	
+	@Test
+	void shouldSuccessfullyPullImage(){
+		def CommandOutput output = dockerClient.pull( getRepositoryGoodString() )
+		assert output.standardOut.toLowerCase().contains( 'digest' )
+	}
+	
+	@Test
+	void shouldFailToPushImage(){
+		def CommandOutput output = dockerClient.push( getRepositoryBadString() )
+		assert output.standardErr.contains( 'Repository does not exist' )
+	}
+	
+	@Test
+	void shouldSuccessfullyPushImage(){
+		def CommandOutput output = dockerClient.push( getRepositoryGoodString( ))
+		assert output.standardOut.toLowerCase().contains( 'digest' )
+	}
+	
+	@Test
+	void shouldFailToTagImage(){
+		def CommandOutput output = dockerClient.tagImage( '1234', getRepositoryBadStringWithVersion() )
+		assert output.standardErr.toLowerCase().contains( 'no such id: 1234' )
+	}
+	
+	@Test
+	void shouldSuccessfullyTagImage(){
+		def CommandOutput output = dockerClient.tagImage( 'cca3762c12a3', getRepositoryGoodStringWithVersion() )
+		assert output.standardErr.empty
+		assert output.standardOut.empty
+	}
+	
+	@Test
+	void shouldFailToRetrieveImageId(){
+		def CommandOutput output = dockerClient.retrieveImageId( getRepositoryBadStringWithVersion() )
+		assert output.standardErr.empty
+		assert output.standardOut.empty
+	}
+	
+	@Test
+	void shouldSucessfullyRetrieveImageId(){
+		def CommandOutput output = dockerClient.retrieveImageId( getRepositoryGoodStringWithVersion() )
+		assert output.standardErr.empty
+		assert !output.standardOut.empty
+	}
+	
+	@Test
+	void shouldSuccessfullyPromoteImageBetweenRepositories(){
+		def currentRepoString = getRepositoryGoodStringWithVersion()
+		def newRepoString = dockerClient.buildRepositoryStringWithVersion( dockerRegistryHost, newProjectName, imageName, 'latest' )
+		def CommandOutput output = dockerClient.promoteImageBetweenRepositories( currentRepoString, newRepoString )
+		assert output.standardOut.toLowerCase().contains( 'digest' )
+	}
+	
+	@Test
+	void shouldTrimImageString(){
+		def CommandOutput imageId = dockerClient.retrieveImageId( getRepositoryGoodStringWithVersion() ) 
+		def String trimmedImageIdString = dockerClient.trimImageId( imageId.standardOut )
+		def pattern = ~/[0-9a-f]+/
+		assert trimmedImageIdString =~ pattern
+	}
+	
+	String getRepositoryGoodString(){
+		return dockerClient.buildRepositoryString( dockerRegistryHost, projectName, imageName )
+	}
+	
+	String getRepositoryGoodStringWithVersion(){
+		return dockerClient.buildRepositoryStringWithVersion( dockerRegistryHost, projectName, imageName, 'latest' )
+	}
+	
+	String getRepositoryBadString(){
+		return dockerClient.buildRepositoryString( dockerRegistryHost, projectName, 'foobar' )
+	}
+	
+	String getRepositoryBadStringWithVersion(){
+		return dockerClient.buildRepositoryStringWithVersion( dockerRegistryHost, projectName, 'foobar', 'latest' )
+	}
+}

--- a/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
+++ b/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
@@ -1,0 +1,33 @@
+package com.rhc
+
+import org.junit.BeforeClass
+import org.junit.Test
+
+class OpenShiftClientTests{
+	
+	def static hostName = "env3-1-master.innovation.labs.redhat.com"
+	def static appName = "infographic-node-app"
+	def static projectName = "holmes-playground"
+	def static openShiftClient = new com.rhc.OpenShiftClient()
+	
+	@BeforeClass
+	static void shouldLoginToOpenShift(){
+		openShiftClient.login( hostName )
+		def CommandOutput output = openShiftClient.getWhoAmI()
+		assert output.standardOut.trim().equals( 'joe' )
+	}
+	
+	@Test
+	void shouldStartBuild(){
+		def CommandOutput buildName = openShiftClient.startBuild( appName, projectName )
+		def pattern = ~/${appName}-[1-9]+/
+		assert buildName.standardOut =~ pattern
+	}
+	
+	@Test
+	void shouldGetUserToken(){
+		def CommandOutput userToken = openShiftClient.getUserToken()
+		def pattern = ~/[A-Za-z0-9-_]+/
+		assert userToken.standardOut.trim() =~ pattern
+	}
+}

--- a/vars/developmentPipeline.groovy
+++ b/vars/developmentPipeline.groovy
@@ -7,12 +7,18 @@ def call(body) {
     body()
 
     // now build, based on the configuration provided
-    node {
-        
-        buildSnapshotStage( config )
-        
-        deploySnapshotStage( config )
+    def pipelineHelper = new com.rhc.PipelineHelper()
 
+    node {
+        stage 'Checkout Code'
+        checkout scm
+
+        stage 'Build App'
+        pipelineHelper.buildApplication( config )
+
+        stage 'Build and Deploy Image'
+        pipelineHelper.buildAndDeployImage( config )
+        
         stage 'smoke test snapshot'
 
         stage 'unit test'
@@ -33,50 +39,4 @@ def call(body) {
             echo "${config.acceptanceTestCommand}"
         }    
     }, failFast: true
-}
-
-def getOpenShiftAppName(){
-    return "name possibly from Jenkins Job?"
-}
-
-def buildSnapshotStage( config ){
-    stage 'build snapshot'
-    checkout scm
-    
-    if ( config.appRootContext ){
-        dir ( config.appRootContext ){   
-            buildSnapshot(config)
-        }
-    } else {
-        buildSnapshot(config)
-    }   
-}
-
-def buildSnapshot(config){
-
-    def tools = ['node-0.10', 'Maven3.3.9']
-
-    if ( config.buildTool == null ){
-        echo 'No build tool declared. Any commands will execute directly in the shell.'
-        for (int i=0; i<config.buildCommands.size(); i++){
-            def command = config.buildCommands[i]
-            sh "${command}" 
-        }
-    } else if ( config.buildTool in tools ) {
-        def toolHome = tool "${config.buildTool}"
-        for (int i=0; i<config.buildCommands.size(); i++){
-            def command = config.buildCommands[i]
-            sh "${toolHome}/bin/${command}" 
-        }
-    } else {
-        error "${config.buildTool} is currently unsupported. Please select one of ${tools}."
-    }
-}
-
-def deploySnapshotStage( config ){
-    stage 'deploy snapshot'
-
-    sh "oc login ${config.ocHost} --insecure-skip-tls-verify=true --username=joe --password=redhat"
-    sh "oc project ${config.projectName}"
-    sh "oc start-build ${config.appName}" //-e ARTIFACT_URL=$hi"
 }

--- a/vars/releasePipeline.groovy
+++ b/vars/releasePipeline.groovy
@@ -1,0 +1,56 @@
+// vars/releasePipeline.groovy
+def call( body ) {
+    // evaluate the body block, and collect configuration into the object
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    def pipelineHelper = new com.rhc.PipelineHelper()
+
+	node {
+
+	stage 'Code Checkout'
+	checkout scm
+
+	stage 'Build App'
+	pipelineHelper.buildApplication( config )
+
+	stage 'Run Tests'
+	echo "We aren't doing anything here yet" // TODO figure out how to handle this
+
+	stage 'Build Image and Deploy to Dev'
+	pipelineHelper.buildAndDeployImage( config )
+
+	// Loop for environments
+	for (int i=0; i<config.envs.size(); i++){
+		def env = config.envs[i].name
+		def msg = config.envs[i].msg
+		stage "Deploy to ${env}"
+		echo "${msg}"
+	}
+
+/*
+	   // Configure FHC&#10;
+	   stage &apos;Configure fhc&apos;&#10;
+	   sh &apos;fhc target {{ rhmap.domain }}&apos;&#10;
+	   sh &apos;fhc login {{ rhmap.username }} {{ rhmap.password }}&apos;&#10;
+	   sh &apos;fhc fhcfg set fhversion 3&apos;&#10;
+	   sh &apos;fhc fhcfg set version 3&apos;&#10;
+	&#10;
+	&#10;
+	   // Trigger cloud git pull&#10;
+	   stage &apos;Trigger cloud git pull&apos;&#10;
+	   sh &apos;/usr/local/bin/fhc git pull {{ item.response.guid }}&apos;&#10;
+	&#10;
+	&#10;
+	   // Trigger opp stage&#10;
+	   stage &apos;Trigger cloud app stage&apos;&#10;
+	   sh &apos;/usr/local/bin/fhc app stage --app={{ item.response.guid }} --env={{ engagement_name }}-development&apos;&#10;
+	&#10;
+	&#10;
+	}&#10;
+*/
+	}
+
+}


### PR DESCRIPTION
TODO: create functions to push images between image-streams via docker tags to support promotion. This PR simply proves that we make the number of Environments dynamic in the pipeline, with support for an arbitrary number of params via groovy maps. 

Moved reusable functions to [PipelineHelper.groovy](PipelineHelper.groovy) and [OpenShiftClient.groovy](OpenShiftClient.groovy) as is done in the fabric8.io project.

See https://github.com/rht-labs/infographic-node-app/pull/4 for an example of how this new code looks for clients.

Also support for arbitrary image build commands now (via `config.buildImageCommands` list)
