### PR TITLE
oc build polling

### DIFF
--- a/src/com/rhc/CommandExecutor.groovy
+++ b/src/com/rhc/CommandExecutor.groovy
@@ -7,16 +7,17 @@ def CommandOutput executeInJenkinsOrGroovy( String command ){
 
 	try {
 		sh "${command} > output.txt"
-		def outputString = readFile( 'output.txt' )
-		def CommandOutput output = new CommandOutput()
+		String outputString = readFile( 'output.txt' )
+		CommandOutput output = new CommandOutput()
 		output.standardOut = outputString
 		return output
 	} catch (err){
 		if ( err instanceof MissingMethodException ) { // this means we are running outside of Jenkins
 			println( "Jenkins pipeline syntax failed. Falling back to groovy.execute() ")
-			def sout = new StringBuilder(), serr = new StringBuilder()
+			StringBuilder sout = new StringBuilder()
+			StringBuilder serr = new StringBuilder()
 			try {
-				def proc = command.execute()
+				Process proc = command.execute()
 				proc.consumeProcessOutput(sout, serr)
 				proc.waitForOrKill( getCommandTimeout() )
 				println("Provided command ${command} suceeded with the following output:")
@@ -25,7 +26,7 @@ def CommandOutput executeInJenkinsOrGroovy( String command ){
 				println("Provided command ${command} failed with the following exception:")
 				println( err2 )
 			} finally {
-				def CommandOutput output = new CommandOutput()
+				CommandOutput output = new CommandOutput()
 				output.standardOut = sout
 				output.standardErr = serr
 				return output;

--- a/src/com/rhc/CommandOutput.groovy
+++ b/src/com/rhc/CommandOutput.groovy
@@ -1,6 +1,6 @@
 package com.rhc
 
 class CommandOutput implements Serializable {
-	def String standardOut
-	def String standardErr
+	String standardOut
+	String standardErr
 }

--- a/src/com/rhc/DockerClient.groovy
+++ b/src/com/rhc/DockerClient.groovy
@@ -2,143 +2,143 @@ package com.rhc
 
 import java.util.regex.Pattern
 
-def CommandOutput login( String host, String userToken ){
-	CommandExecutor commandExecutor = new CommandExecutor();
-	String command = "docker login -u='joe' -e='jholmes@redhat.com' -p=${userToken} ${host}"
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	return output
-}
+class DockerClient implements Serializable {
 
-def CommandOutput pushOrPull( String operation, String repositoryString ){
-	CommandExecutor commandExecutor = new CommandExecutor();
-	String command = "docker ${operation} ${repositoryString}"
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	return output
-}
-
-def CommandOutput pull( String repositoryString ){
-	return pushOrPull( 'pull', repositoryString )
-}
-
-def CommandOutput push( String repositoryString ){
-	return pushOrPull( 'push', repositoryString )
-}
-
-def CommandOutput tagImage( String imageId, String repositoryStringWithVersion ){
-	String dockerVersion = getDockerClientVersionTrimmedString()
-	if (imageId == null || imageId.empty ){
-		println( 'imageId is empty' )
+	CommandExecutor commandExecutor = new CommandExecutor()
+	
+	CommandOutput login( String host, String userToken ){
+		String command = "docker login -u='joe' -e='jholmes@redhat.com' -p=${userToken} ${host}"
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		return output
 	}
-	return tagImage( imageId, repositoryStringWithVersion, dockerVersion )
-}
 
-def CommandOutput tagImage( String imageId, String repositoryStringWithVersion, String dockerVersion ){
-	Pattern oneNinePattern = getDockerOneNineRegex()
-	String command
-	if ( dockerVersion =~ oneNinePattern ){
-		command = "docker tag -f ${imageId} ${repositoryStringWithVersion}" // this is not unit tested currently
-	} else {
-		command = "docker tag ${imageId} ${repositoryStringWithVersion}"
+	CommandOutput pushOrPull( String operation, String repositoryString ){
+		String command = "docker ${operation} ${repositoryString}"
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		return output
 	}
-	CommandExecutor commandExecutor = new CommandExecutor();
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	return output
-}
 
-def CommandOutput retrieveImageId( String repositoryStringWithVersion, String dockerVersion ){
-	Pattern oneNinePattern = getDockerOneNineRegex()
-	String command
-	boolean legacyAPI = false
-	if ( dockerVersion =~ oneNinePattern ){
-		command = "docker images ${repositoryStringWithVersion}"
-		legacyAPI = true
-	} else {
-		command = "docker images --format '{{.ID}}' ${repositoryStringWithVersion}"
+	CommandOutput pull( String repositoryString ){
+		return pushOrPull( 'pull', repositoryString )
 	}
-	CommandExecutor commandExecutor = new CommandExecutor();
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	if ( dockerVersion =~ oneNinePattern ){
-		String outputString = output.standardOut
-		String[] outputTokens = outputString.split( '\\s+' )
-		boolean found = false
-		for ( int i=0; i<outputTokens.length; i++ ){
-			if ( ( outputTokens[i] =~ getDockerOneTenImageIdRegex() ) || outputTokens[i] =~ getDockerOneNineImageIdRegex() ) {
-				output.standardOut = outputTokens[i]
-				found = true
+
+	CommandOutput push( String repositoryString ){
+		return pushOrPull( 'push', repositoryString )
+	}
+
+	CommandOutput tagImage( String imageId, String repositoryStringWithVersion ){
+		String dockerVersion = getDockerClientVersionTrimmedString()
+		if (imageId == null || imageId.empty ){
+			println( 'imageId is empty' )
+		}
+		return tagImage( imageId, repositoryStringWithVersion, dockerVersion )
+	}
+
+	CommandOutput tagImage( String imageId, String repositoryStringWithVersion, String dockerVersion ){
+		Pattern oneNinePattern = getDockerOneNineRegex()
+		String command
+		if ( dockerVersion =~ oneNinePattern ){
+			command = "docker tag -f ${imageId} ${repositoryStringWithVersion}" // this is not unit tested currently
+		} else {
+			command = "docker tag ${imageId} ${repositoryStringWithVersion}"
+		}
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		return output
+	}
+
+	CommandOutput retrieveImageId( String repositoryStringWithVersion, String dockerVersion ){
+		Pattern oneNinePattern = getDockerOneNineRegex()
+		String command
+		boolean legacyAPI = false
+		if ( dockerVersion =~ oneNinePattern ){
+			command = "docker images ${repositoryStringWithVersion}"
+			legacyAPI = true
+		} else {
+			command = "docker images --format '{{.ID}}' ${repositoryStringWithVersion}"
+		}
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		if ( dockerVersion =~ oneNinePattern ){
+			String outputString = output.standardOut
+			String[] outputTokens = outputString.split( '\\s+' )
+			boolean found = false
+			for ( int i=0; i<outputTokens.length; i++ ){
+				if ( ( outputTokens[i] =~ getDockerOneTenImageIdRegex() ) || outputTokens[i] =~ getDockerOneNineImageIdRegex() ) {
+					output.standardOut = outputTokens[i]
+					found = true
+				}
+			}
+			if ( found == false ){
+				output.standardOut = ''
 			}
 		}
-		if ( found == false ){
-			output.standardOut = ''
+		return output
+	}
+
+	CommandOutput retrieveImageId( String repositoryStringWithVersion ){
+		String dockerVersion = getDockerClientVersionTrimmedString()
+		return retrieveImageId( repositoryStringWithVersion, dockerVersion )
+	}
+
+	CommandOutput promoteImageBetweenRepositories( String currentRepositoryWithVersion, String newRepositoryWithVersion ){
+		pull( currentRepositoryWithVersion )
+		CommandOutput imageId = retrieveImageId( currentRepositoryWithVersion )
+		tagImage( trimImageId(imageId.standardOut), newRepositoryWithVersion )
+		CommandOutput commandOutput = push( newRepositoryWithVersion )
+		return commandOutput
+	}
+
+	String trimImageId( String imageIdString ){
+		String trimmedString = imageIdString.trim()
+		if ( trimmedString.length() > 12 ){
+			def length = trimmedString.length()
+			length -= 1
+			return trimmedString.trim().substring(1, length)
+		} else {
+			return trimmedString
 		}
 	}
-	return output
-}
 
-def CommandOutput retrieveImageId( String repositoryStringWithVersion ){
-	String dockerVersion = getDockerClientVersionTrimmedString()
-	return retrieveImageId( repositoryStringWithVersion, dockerVersion )
-}
-
-def CommandOutput promoteImageBetweenRepositories( String currentRepositoryWithVersion, String newRepositoryWithVersion ){
-	pull( currentRepositoryWithVersion )
-	CommandOutput imageId = retrieveImageId( currentRepositoryWithVersion )
-	tagImage( trimImageId(imageId.standardOut), newRepositoryWithVersion )
-	CommandOutput commandOutput = push( newRepositoryWithVersion )
-	return commandOutput
-}
-
-def String trimImageId( String imageIdString ){
-	String trimmedString = imageIdString.trim()
-	if ( trimmedString.length() > 12 ){
-		def length = trimmedString.length()
-		length -= 1
-		return trimmedString.trim().substring(1, length)
-	} else {
-		return trimmedString
+	CommandOutput getDockerClientVersion(){
+		String command = "docker -v"
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		return output
 	}
-}
 
-def CommandOutput getDockerClientVersion(){
-	CommandExecutor commandExecutor = new CommandExecutor();
-	String command = "docker -v"
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	return output
-}
+	String getDockerClientVersionTrimmedString(){
+		CommandOutput output = getDockerClientVersion()
 
-def String getDockerClientVersionTrimmedString(){
-	CommandOutput output = getDockerClientVersion()
+		String[] tokens = output.standardOut.split(' ')
+		String versionToken = tokens[2]
+		String versionString = versionToken.substring(0, versionToken.size()-1)
 
-	String[] tokens = output.standardOut.split(' ')
-	String versionToken = tokens[2]
-	String versionString = versionToken.substring(0, versionToken.size()-1)
-
-	return versionString
-}
-
-def String buildRepositoryString( String host, String projectName, String imageName ){
-	return "${host}/${projectName}/${imageName}"
-}
-
-def String buildRepositoryStringWithVersion( String host, String projectName, String imageName, String version ){
-	def repositoryString = buildRepositoryString( host, projectName, imageName )
-	return "${repositoryString}:${version}"
-}
-
-def Pattern getDockerOneTenImageIdRegex(){
-	return ~/[0-9a-f]{12}/
-}
-
-def Pattern getDockerOneNineImageIdRegex(){
-	return ~/sha256:[0-9a-f]{5}/
-}
-
-def getImageIdRegex(){
-	if ( getDockerClientVersionTrimmedString() =~ getDockerOneNineRegex() ){
-		return getDockerOneNineImageIdRegex()
-	} else {
-		return getDockerOneTenImageIdRegex()
+		return versionString
 	}
-}
-def Pattern getDockerOneNineRegex(){
-	return ~/1.9.[0-9]+/
+
+	String buildRepositoryString( String host, String projectName, String imageName ){
+		return "${host}/${projectName}/${imageName}"
+	}
+
+	String buildRepositoryStringWithVersion( String host, String projectName, String imageName, String version ){
+		def repositoryString = buildRepositoryString( host, projectName, imageName )
+		return "${repositoryString}:${version}"
+	}
+
+	Pattern getDockerOneTenImageIdRegex(){
+		return ~/[0-9a-f]{12}/
+	}
+
+	Pattern getDockerOneNineImageIdRegex(){
+		return ~/sha256:[0-9a-f]{5}/
+	}
+
+	Pattern getImageIdRegex(){
+		if ( getDockerClientVersionTrimmedString() =~ getDockerOneNineRegex() ){
+			return getDockerOneNineImageIdRegex()
+		} else {
+			return getDockerOneTenImageIdRegex()
+		}
+	}
+	Pattern getDockerOneNineRegex(){
+		return ~/1.9.[0-9]+/
+	}
 }

--- a/src/com/rhc/OpenShiftClient.groovy
+++ b/src/com/rhc/OpenShiftClient.groovy
@@ -3,36 +3,36 @@ package com.rhc
 import com.rhc.CommandOutput
 
 def login( String host ){
-	def commandExecutor = new CommandExecutor();
-	def command = "oc login ${host} --insecure-skip-tls-verify=true --username=joe --password=redhat"
+	CommandExecutor commandExecutor = new CommandExecutor();
+	String command = "oc login ${host} --insecure-skip-tls-verify=true --username=joe --password=redhat"
 	commandExecutor.executeInJenkinsOrGroovy( command )
 }
 
 def CommandOutput startBuild( String appName, String projectName ){
-	def commandExecutor = new CommandExecutor();
-	def command = "oc start-build ${appName} -n ${projectName}"
-	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	CommandExecutor commandExecutor = new CommandExecutor();
+	String command = "oc start-build ${appName} -n ${projectName}"
+	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
 	return output
 }
 
 def CommandOutput getWhoAmI(){
-	def commandExecutor = new CommandExecutor();
-	def command = "oc whoami"
-	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	CommandExecutor commandExecutor = new CommandExecutor();
+	String command = "oc whoami"
+	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
 	return output
 }
 
 def CommandOutput getUserToken(){
-	def commandExecutor = new CommandExecutor();
-	def command = "oc whoami -t"
-	def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+	CommandExecutor commandExecutor = new CommandExecutor();
+	String command = "oc whoami -t"
+	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
 	return output
 }
 
 def String getTrimmedUserToken(){
-	def CommandOutput tokenOutput = getUserToken()
-	def tokenStream = tokenOutput.getStandardOut()
-	def tokenString = tokenStream.toString()
-	def tokenTrimmedString = tokenString.trim()
+	CommandOutput tokenOutput = getUserToken()
+	String tokenStream = tokenOutput.getStandardOut()
+	String tokenString = tokenStream.toString()
+	String tokenTrimmedString = tokenString.trim()
 	return tokenTrimmedString
 }

--- a/src/com/rhc/OpenShiftClient.groovy
+++ b/src/com/rhc/OpenShiftClient.groovy
@@ -2,74 +2,76 @@ package com.rhc
 
 import groovy.json.JsonSlurper
 
-def login( String host ){
-	CommandExecutor commandExecutor = new CommandExecutor();
-	String command = "oc login ${host} --insecure-skip-tls-verify=true --username=joe --password=redhat"
-	commandExecutor.executeInJenkinsOrGroovy( command )
-}
+class OpenShiftClient implements Serializable {
+	
+	CommandExecutor commandExecutor = new CommandExecutor()
+	long maxMillisecondsToWait = 60000  
+	long waitIntervalInMilliseconds = 1000 
 
-def CommandOutput startBuild( String appName, String projectName ){
-	CommandExecutor commandExecutor = new CommandExecutor();
-	String command = "oc start-build ${appName} -n ${projectName}"
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	return output
-}
+	void login( String host ){
+		String command = "oc login ${host} --insecure-skip-tls-verify=true --username=joe --password=redhat"
+		commandExecutor.executeInJenkinsOrGroovy( command )
+	}
 
-def CommandOutput getWhoAmI(){
-	CommandExecutor commandExecutor = new CommandExecutor();
-	String command = "oc whoami"
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	return output
-}
+	CommandOutput startBuild( String appName, String projectName ){
+		String command = "oc start-build ${appName} -n ${projectName}"
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		return output
+	}
 
-def CommandOutput getUserToken(){
-	CommandExecutor commandExecutor = new CommandExecutor();
-	String command = "oc whoami -t"
-	CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
-	return output
-}
+	CommandOutput getWhoAmI(){
+		String command = "oc whoami"
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		return output
+	}
 
-def String getTrimmedUserToken(){
-	CommandOutput tokenOutput = getUserToken()
-	String tokenStream = tokenOutput.getStandardOut()
-	String tokenString = tokenStream.toString()
-	String tokenTrimmedString = tokenString.trim()
-	return tokenTrimmedString
-}
+	CommandOutput getUserToken(){
+		String command = "oc whoami -t"
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( command )
+		return output
+	}
 
-def void waitUntilBuildIsComplete( String buildId, String projectName ){
-	long maxMillisecondsToWait = 60000  // TODO make this configurable
-	long waitIntervalInMilliseconds = 1000 // TODO make this configurable
-	long timeAlreadySpentWaiting = 0
-	String trimmedBuildId = buildId.trim()
-	while ( true ){
-		String status = getBuildStatus( trimmedBuildId, projectName )
-		println( "Build ${trimmedBuildId} is ${status}")
-		if ( status.equalsIgnoreCase( 'Complete' ) ){
-			break
-		} else{
-			if ( timeAlreadySpentWaiting == maxMillisecondsToWait){
-				throw new Exception( "Max interval to poll exceeded - ${maxMillisecondsToWait}" )
-			} else {
-				timeAlreadySpentWaiting += waitIntervalInMilliseconds
-				Thread.sleep( waitIntervalInMilliseconds )
+	String getTrimmedUserToken(){
+		CommandOutput tokenOutput = getUserToken()
+		String tokenStream = tokenOutput.getStandardOut()
+		String tokenString = tokenStream.toString()
+		String tokenTrimmedString = tokenString.trim()
+		return tokenTrimmedString
+	}
+
+	void waitUntilBuildIsComplete( String buildId, String projectName ){
+
+		long timeAlreadySpentWaiting = 0
+		String trimmedBuildId = buildId.trim()
+		while ( true ){
+			String status = getBuildStatus( trimmedBuildId, projectName )
+			println( "Build ${trimmedBuildId} is ${status}")
+			if ( status.equalsIgnoreCase( 'Complete' ) ){
+				break
+			} else{
+				if ( timeAlreadySpentWaiting == maxMillisecondsToWait){
+					throw new Exception( "Max interval to poll exceeded - ${maxMillisecondsToWait}" )
+				} else {
+					timeAlreadySpentWaiting += waitIntervalInMilliseconds
+					Thread.sleep( waitIntervalInMilliseconds )
+				}
 			}
 		}
 	}
-}
 
 
-def String startBuildAndWaitUntilComplete( String appName, String projectName ){
-	CommandOutput buildName = startBuild( appName, projectName )
-	waitUntilBuildIsComplete( buildName.standardOut, projectName )
-	return buildName.standardOut.trim()
-}
+	String startBuildAndWaitUntilComplete( String appName, String projectName ){
+		CommandOutput buildName = startBuild( appName, projectName )
+		waitUntilBuildIsComplete( buildName.standardOut, projectName )
+		return buildName.standardOut.trim()
+	}
 
-def String getBuildStatus( String buildId, String projectName ){
-	CommandOutput output = new CommandExecutor().executeInJenkinsOrGroovy( "oc get builds ${buildId} -n ${projectName} -o json" )
-	assert output.standardOut != null
-	assert !output.standardOut.empty
-	assert output.standardErr == null || output.standardErr.empty
-	def result = new JsonSlurper().parseText( output.standardOut )
-	return result.status.phase
+	String getBuildStatus( String buildId, String projectName ){
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( "oc get builds ${buildId} -n ${projectName} -o json" )
+		assert output.standardOut != null
+		assert !output.standardOut.empty
+		assert output.standardErr == null || output.standardErr.empty
+		def result = new JsonSlurper().parseText( output.standardOut )
+		return result.status.phase
+	}
 }

--- a/src/com/rhc/PipelineHelper.groovy
+++ b/src/com/rhc/PipelineHelper.groovy
@@ -28,7 +28,7 @@ def getBuildTools(){
 
 def startDefaultOpenShiftBuildAndDeploy( config ){
     def oc = new OpenShiftClient()
-    oc.startBuild( config.appName, config.projectName )
+    oc.startBuildAndWaitUntilComplete( config.appName, config.projectName )
 }
 
 def executeBuildCommands( config ){

--- a/src/test/groovy/com/rhc/CommandExecutorTests.groovy
+++ b/src/test/groovy/com/rhc/CommandExecutorTests.groovy
@@ -4,18 +4,18 @@ import org.junit.Test
 
 class CommandExecutorTests {
 
-	def commandExecutor = new CommandExecutor();
+	CommandExecutor commandExecutor = new CommandExecutor();
 	
 	@Test
 	void shouldPrintToStandardOut(){
-		def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( 'pwd' )
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( 'pwd' )
 		assert !output.standardOut.empty
 		assert output.standardErr.empty
 	}
 	
 	@Test
 	void shouldPrintToStandardError(){
-		def CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( 'thisCommandShouldFail' )
+		CommandOutput output = commandExecutor.executeInJenkinsOrGroovy( 'thisCommandShouldFail' )
 		assert output.standardOut.empty
 		assert output.standardErr.empty
 	}

--- a/src/test/groovy/com/rhc/DockerClientTests.groovy
+++ b/src/test/groovy/com/rhc/DockerClientTests.groovy
@@ -7,19 +7,19 @@ import org.junit.Test
 
 class DockerClientTests {
 
-	static String dockerRegistryHost = 'registry.env3-1.innovation.labs.redhat.com'
-	static String openShiftHost = 'env3-1-master.innovation.labs.redhat.com'
-	static String projectName = 'holmes-stage'
-	static String newProjectName = 'holmes-prod'
-	static String imageName = 'infographic-node-app'
+	static final String DOCKER_REGISTRY_HOST = 'registry.env3-1.innovation.labs.redhat.com'
+	static final String OPENSHIFT_HOST = 'env3-1-master.innovation.labs.redhat.com'
+	static final String PROJECT_NAME = 'holmes-stage'
+	static final String NEW_PROJECT_NAME = 'holmes-prod'
+	static final String IMAGE_NAME = 'infographic-node-app'
 	static DockerClient dockerClient = new DockerClient()
 	static OpenShiftClient openShiftClient = new OpenShiftClient()
 
 
 	@BeforeClass
 	static void shouldLoginToRegistry(){
-		openShiftClient.login( openShiftHost )
-		CommandOutput output = dockerClient.login( dockerRegistryHost, openShiftClient.getTrimmedUserToken() )
+		openShiftClient.login( OPENSHIFT_HOST )
+		CommandOutput output = dockerClient.login( DOCKER_REGISTRY_HOST, openShiftClient.getTrimmedUserToken() )
 		assert output.standardOut.contains( 'Login Succeeded' )
 	}
 
@@ -94,7 +94,7 @@ class DockerClientTests {
 	@Test
 	void shouldSuccessfullyPromoteImageBetweenRepositories(){
 		String currentRepoString = getRepositoryGoodStringWithVersion()
-		String newRepoString = dockerClient.buildRepositoryStringWithVersion( dockerRegistryHost, newProjectName, imageName, 'latest' )
+		String newRepoString = dockerClient.buildRepositoryStringWithVersion( DOCKER_REGISTRY_HOST, NEW_PROJECT_NAME, IMAGE_NAME, 'latest' )
 		CommandOutput output = dockerClient.promoteImageBetweenRepositories( currentRepoString, newRepoString )
 		assert output.standardOut.toLowerCase().contains( 'digest' )
 	}
@@ -123,18 +123,18 @@ class DockerClientTests {
 	}
 
 	String getRepositoryGoodString(){
-		return dockerClient.buildRepositoryString( dockerRegistryHost, projectName, imageName )
+		return dockerClient.buildRepositoryString( DOCKER_REGISTRY_HOST, PROJECT_NAME, IMAGE_NAME )
 	}
 
 	String getRepositoryGoodStringWithVersion(){
-		return dockerClient.buildRepositoryStringWithVersion( dockerRegistryHost, projectName, imageName, 'latest' )
+		return dockerClient.buildRepositoryStringWithVersion( DOCKER_REGISTRY_HOST, PROJECT_NAME, IMAGE_NAME, 'latest' )
 	}
 
 	String getRepositoryBadString(){
-		return dockerClient.buildRepositoryString( dockerRegistryHost, projectName, 'foobar' )
+		return dockerClient.buildRepositoryString( DOCKER_REGISTRY_HOST, PROJECT_NAME, 'foobar' )
 	}
 
 	String getRepositoryBadStringWithVersion(){
-		return dockerClient.buildRepositoryStringWithVersion( dockerRegistryHost, projectName, 'foobar', 'latest' )
+		return dockerClient.buildRepositoryStringWithVersion( DOCKER_REGISTRY_HOST, PROJECT_NAME, 'foobar', 'latest' )
 	}
 }

--- a/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
+++ b/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
@@ -1,33 +1,40 @@
 package com.rhc
 
+import java.util.regex.Pattern
+
 import org.junit.BeforeClass
 import org.junit.Test
 
 class OpenShiftClientTests{
 	
-	def static hostName = "env3-1-master.innovation.labs.redhat.com"
-	def static appName = "infographic-node-app"
-	def static projectName = "holmes-playground"
-	def static openShiftClient = new com.rhc.OpenShiftClient()
+	static String hostName = "env3-1-master.innovation.labs.redhat.com"
+	static String appName = "infographic-node-app"
+	static String projectName = "holmes-playground"
+	static OpenShiftClient openShiftClient = new com.rhc.OpenShiftClient()
 	
 	@BeforeClass
 	static void shouldLoginToOpenShift(){
 		openShiftClient.login( hostName )
-		def CommandOutput output = openShiftClient.getWhoAmI()
+		CommandOutput output = openShiftClient.getWhoAmI()
 		assert output.standardOut.trim().equals( 'joe' )
 	}
 	
 	@Test
 	void shouldStartBuild(){
-		def CommandOutput buildName = openShiftClient.startBuild( appName, projectName )
-		def pattern = ~/${appName}-[1-9]+/
+		CommandOutput buildName = openShiftClient.startBuild( appName, projectName )
+		Pattern pattern = ~/${appName}-[1-9]+/
 		assert buildName.standardOut =~ pattern
 	}
 	
 	@Test
 	void shouldGetUserToken(){
-		def CommandOutput userToken = openShiftClient.getUserToken()
-		def pattern = ~/[A-Za-z0-9-_]+/
+		CommandOutput userToken = openShiftClient.getUserToken()
+		Pattern pattern = ~/[A-Za-z0-9-_]+/
 		assert userToken.standardOut.trim() =~ pattern
+	}
+	
+	@Test
+	void shouldWaitUntilBuildIsComplete(){
+		assert false
 	}
 }

--- a/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
+++ b/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
@@ -9,22 +9,22 @@ import groovy.json.JsonSlurper;
 
 class OpenShiftClientTests{
 	
-	static String hostName = "env3-1-master.innovation.labs.redhat.com"
-	static String appName = "infographic-node-app"
-	static String projectName = "holmes-playground"
-	static OpenShiftClient openShiftClient = new com.rhc.OpenShiftClient()
+	static final String HOST_NAME = "env3-1-master.innovation.labs.redhat.com"
+	static final String APP_NAME = "infographic-node-app"
+	static final String PROJECT_NAME = "holmes-playground"
+	static final OpenShiftClient openShiftClient = new com.rhc.OpenShiftClient()
 	
 	@BeforeClass
 	static void shouldLoginToOpenShift(){
-		openShiftClient.login( hostName )
+		openShiftClient.login( HOST_NAME )
 		CommandOutput output = openShiftClient.getWhoAmI()
 		assert output.standardOut.trim().equals( 'joe' )
 	}
 	
 	@Test
 	void shouldStartBuild(){
-		CommandOutput buildName = openShiftClient.startBuild( appName, projectName )
-		Pattern pattern = ~/${appName}-[1-9]+/
+		CommandOutput buildName = openShiftClient.startBuild( APP_NAME, PROJECT_NAME )
+		Pattern pattern = ~/${APP_NAME}-[1-9]+/
 		assert buildName.standardOut =~ pattern
 	}
 	
@@ -37,8 +37,8 @@ class OpenShiftClientTests{
 	
 	@Test
 	void shouldStartBuildAndWaitUntilBuildIsComplete(){
-		String buildName = openShiftClient.startBuildAndWaitUntilComplete( appName, projectName )
-		String status = openShiftClient.getBuildStatus( buildName, projectName )
+		String buildName = openShiftClient.startBuildAndWaitUntilComplete( APP_NAME, PROJECT_NAME )
+		String status = openShiftClient.getBuildStatus( buildName, PROJECT_NAME )
 		assert status.equalsIgnoreCase( 'Complete' )
 	}
 	

--- a/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
+++ b/src/test/groovy/com/rhc/OpenShiftClientTests.groovy
@@ -5,6 +5,8 @@ import java.util.regex.Pattern
 import org.junit.BeforeClass
 import org.junit.Test
 
+import groovy.json.JsonSlurper;
+
 class OpenShiftClientTests{
 	
 	static String hostName = "env3-1-master.innovation.labs.redhat.com"
@@ -34,7 +36,10 @@ class OpenShiftClientTests{
 	}
 	
 	@Test
-	void shouldWaitUntilBuildIsComplete(){
-		assert false
+	void shouldStartBuildAndWaitUntilBuildIsComplete(){
+		String buildName = openShiftClient.startBuildAndWaitUntilComplete( appName, projectName )
+		String status = openShiftClient.getBuildStatus( buildName, projectName )
+		assert status.equalsIgnoreCase( 'Complete' )
 	}
+	
 }


### PR DESCRIPTION
This PR uses `oc get build <buildId> -o json` with the Groovy `JsonSlupper` to support a wait state where we poll openshift to get the status of a build and then ensure it is `Complete` before moving on. This helps avoid race conditions in the pipeline and is a better reflection of the time it takes to run a build.

`PipelineHelper` updated to use this code and http://cicd-1.innovation.labs.redhat.com:8090/ has been update as well for testing purposes.

Also some syntax clean up based on @mdanter's feedback